### PR TITLE
Phase 2c: real publish/reject + build-aircraft-packs --aircraft mode

### DIFF
--- a/.github/workflows/scan-livery.yml
+++ b/.github/workflows/scan-livery.yml
@@ -51,8 +51,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    # publish.py commits the updated pack.json back to main and pushes.
+    # Without contents:write the default GITHUB_TOKEN is read-only and
+    # the push step fails. fetch-depth: 0 is also needed so git push
+    # can build the right ancestry context.
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -110,11 +119,14 @@ jobs:
         if: steps.scanner.outputs.passed == 'True'
         env:
           VRS_SSH_KEY: ${{ secrets.VRS_SSH_KEY }}
+          VRS_SSH_HOST: ${{ secrets.VRS_SSH_HOST }}
           DISCORD_LIVERIES_WEBHOOK: ${{ secrets.DISCORD_LIVERIES_WEBHOOK }}
           UPLOADER_EMAIL: ${{ inputs.uploader_email }}
           UPLOADER_ID: ${{ inputs.uploader_id }}
           ORIGINAL_FILENAME: ${{ inputs.original_filename }}
           UPLOAD_ID: ${{ inputs.upload_id }}
+          # GITHUB_TOKEN is set automatically; publish.py uses git which
+          # reads the auth helper actions/checkout configured for us.
         run: python -m scripts.scanner.publish /tmp/livery.zip /tmp/verdict.json
 
       - name: Reject (on fail)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,10 +1,20 @@
 # PLAN.md -- VRSMods Liveries Ingest Pipeline
 
-Status: **Phase 1 done 2026-05-26.** Per-aircraft livery sub-packs
-live, two-channel OMM model verified end-to-end (IL-76MD install
-landed at `Saved Games\DCS\Liveries\IL-76MD\MD USSR\` with today's
-date, no parse errors). Phase 2 (scanner + GHA + ProjectSend cron)
-is next when we pick it back up.
+Status:
+- **Phase 1 done 2026-05-26** -- per-aircraft livery sub-packs live,
+  two-channel OMM model verified end-to-end.
+- **Phase 2a done** -- scanner with 11-test corpus (tier 1-6 checks,
+  Lua AST denylist, encrypted-zip detection).
+- **Phase 2b done 2026-05-27** -- scan-livery.yml workflow validated
+  end-to-end with IL-76MD.zip (sha256 7583e2ba..., run 26489577547).
+- **Phase 2c code landed 2026-05-27** -- publish.py + reject.py real
+  implementations, build-aircraft-packs.py --aircraft + dir-source,
+  extract-livery-source.py one-shot migration script. Lands as
+  ready-to-fire; gracefully no-ops on each missing secret/prereq.
+  See "Phase 2c prereqs to flip on" below.
+- **Phase 3 (ProjectSend cron + signed URL + livery-flag.php endpoint)**
+  is next.
+
 Moved from `~/Dev/VRSInfra/planning-liveries-pipeline.md` on
 2026-05-24; that path is now a thin pointer back here.
 
@@ -65,29 +75,75 @@ start session needs.
 
 ---
 
-## Phase 2 starting position
+## Phase 2c prereqs to flip on
 
-Per the original phasing (below): scanner + GHA `workflow_dispatch`
-ingest. Doable in the existing codebase. Prereqs the user still
-needs to handle:
+publish.py and reject.py are wire-ready. To actually fire end-to-end
+on the next scan-livery run, the user needs to:
 
-- Mint two Discord webhooks: `#liveries` (public) + staff on-call
-  channel (private). Add to GHA repo secrets as
-  `DISCORD_LIVERIES_WEBHOOK` + `DISCORD_STAFF_WEBHOOK`. Plus the
-  on-call role ID.
-- Generate a fine-grained GitHub PAT scoped to
-  `VictorRomeoSierra/VRSMods` with `actions:write` only. Stored on
-  vrs.com at `~/.vrs-pipeline-secrets/gh-token` (mode 0600).
-- Mint a dedicated ed25519 SSH key (not the personal `Shifty` key)
-  with `command=` restriction limiting writes to:
-  - `~/livery-source/`
-  - `~/public_html/Mods/Liveries/`
-  - `~/public_html/Mods/Liveries.zip`
-  - `~/public_html/Mods/repo.xml` (and friends)
-  Private key as `VRS_SSH_KEY` repo secret.
+**Secrets to mint and add as repo secrets in VRSMods:**
 
-None of these block coding the scanner -- they only matter when
-wiring up GHA + ProjectSend in Phase 2/3.
+1. `VRS_SSH_KEY` -- dedicated ed25519 private key for GHA -> vrs.com.
+   Pair the public key into `~/.ssh/authorized_keys` on vrs.com with
+   a `command=` restriction limiting writes to:
+     - `~/livery-source/`
+     - `~/public_html/Mods/Liveries/`
+     - `~/public_html/Mods/Liveries.zip`
+     - `~/public_html/VRSInstall.xml`
+     - `~/public_html/VRSSavedGames.xml`
+     - `~/public_html/Mods/repo.xml`
+2. `VRS_SSH_HOST` -- the user@host string (e.g. `customdc@vrs.com`).
+   Defaults to that in publish.py if unset.
+3. `DISCORD_LIVERIES_WEBHOOK` -- public `#liveries` channel webhook
+   (publish success embeds).
+4. `DISCORD_STAFF_WEBHOOK` -- private staff on-call channel webhook
+   (reject alerts).
+5. `DISCORD_ONCALL_ROLE_ID` -- numeric role ID for `<@&...>` ping in
+   reject embeds.
+6. `VRS_WEBHOOK_KEY` -- HMAC-SHA256 key for the vrs.com quarantine
+   flag POST. Endpoint lands in Phase 3; the secret can be minted
+   now so reject.py is already signing when the endpoint goes live.
+
+**Scripts to deploy to vrs.com:**
+
+7. Copy the updated `scripts/build-aircraft-packs.py` to
+   `~/bin/build-aircraft-packs.py` on vrs.com (it adds `--aircraft`
+   and dir-source mode that publish.py depends on).
+8. Copy `scripts/extract-livery-source.py` to `~/bin/` on vrs.com.
+
+**One-shot migration to run on vrs.com:**
+
+9. `python3.12 ~/bin/extract-livery-source.py` -- materializes
+   `~/livery-source/<src_folder>/<slug>/...` from the monolithic
+   `Liveries.zip` (~25 GB, ~10 min on the cPanel disk). This is the
+   source-of-truth that publish.py rsyncs new slugs into and that
+   build-aircraft-packs.py reads on incremental rebuilds.
+
+**No-PAT note.** publish.py commits pack.json back to main using the
+default `GITHUB_TOKEN` -- the workflow sets `permissions: contents:
+write` so the auth helper actions/checkout installs is sufficient. No
+fine-grained PAT needed for the publish side. (Phase 3's vrs.com cron
+will still need an `actions:write` PAT to dispatch the workflow, but
+that's separate.)
+
+**Branch protection caveat.** `contents: write` raises the
+`GITHUB_TOKEN`'s scope but does NOT bypass branch protection. If
+`main` is configured to require PRs (Phase 1's setup did require it
+-- PR #5 was opened to merge phase-2 into main), the workflow's
+`git push HEAD:main` will fail every publish run. Options:
+
+1. **Allow `github-actions[bot]` to bypass** (Settings -> Branches ->
+   main -> "Allow specified actors to bypass required pull requests").
+   Quickest; needed for the fully-automated end-state.
+2. **Restructure to auto-PR** -- push to `auto/publish-<sha>` and
+   `gh pr create`. Adds a human merge step (defeats automation).
+3. **Skip the push entirely** -- let pack.json drift be repaired by
+   a periodic human PR. Less coupled but a regression.
+
+publish.py is ordered so vrs.com state stays consistent even if the
+push fails: it deploys the new zip + new manifests BEFORE attempting
+the commit + push. If push fails, the only drift is the repo's
+`liveries-index/<aircraft>/pack.json` vs `origin/main`. The GHA run
+summary surfaces this with a recovery hint.
 
 ---
 

--- a/scripts/build-aircraft-packs.py
+++ b/scripts/build-aircraft-packs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Repackage the monolithic Liveries.zip into per-aircraft sub-packs.
+"""Repackage liveries into per-aircraft OMM sub-packs.
 
 Each output zip is structured to match the OvGME / OMM old-fashion
 convention: a single outer folder whose name matches the file's stem,
@@ -22,25 +22,43 @@ remaining `Liveries/<Aircraft>/...` path lands in the right place
 under the user's Saved Games. No ModPack.xml is needed -- OMM's
 default file-name = top-folder parser handles it.
 
+Two source modes:
+
+  - **zip source** (`--source path/to/Liveries.zip`): reads from the
+    monolithic zip the way Phase 1 did. Backwards-compat.
+
+  - **dir source** (`--source path/to/livery-source/`): reads from a
+    directory tree laid out as `<src_folder>/<slug>/<files>` where
+    `<src_folder>` is the pre-RENAME folder name (e.g. `il-76md`, or
+    `F-16C` to fold into F-16C_50). This is the Phase 2c+ shape --
+    publish.py SSH-pushes new slugs into `~/livery-source/` on vrs.com
+    and triggers this script to rebuild just the affected aircraft.
+
+`--aircraft <name>` (may be repeated) restricts the build to one or
+more aircraft. With `--aircraft`, manifest.json is **merged** into
+rather than replaced -- entries for non-rebuilt aircraft are
+preserved. Use this for the publish.py incremental rebuild flow.
+
 Inline transforms applied while repackaging:
   - Case-fix renames (RENAME map: a-10c -> A-10C, etc.)
   - F-16C contents merged into F-16C_50 (user-confirmed)
 
-Idempotent. Single zip-to-zip pass -- no filesystem extraction.
-Output uses ZIP_STORED (the source already stores DDS content
-uncompressed; recompression would waste CPU).
+Idempotent. Single pass per aircraft. Output uses ZIP_STORED (the
+source already stores DDS content uncompressed; recompression would
+waste CPU).
 
 Usage:
-    python3 build-aircraft-packs.py [--source <path>] [--out <dir>]
+    python3 build-aircraft-packs.py [--source <path>] [--out <dir>] [--aircraft <name>...]
 
 Defaults target a vrs.com layout:
     --source $HOME/public_html/Mods/Liveries.zip
     --out    $HOME/public_html/Mods/Liveries
 
-For a local rebuild on the user's workstation:
-    python build-aircraft-packs.py \
-        --source ~/Downloads/Liveries.zip \
-        --out Release/aircraft-packs
+Incremental rebuild (Phase 2c publish.py invocation):
+    python3.12 build-aircraft-packs.py \
+        --source ~/livery-source \
+        --out    ~/public_html/Mods/Liveries \
+        --aircraft IL-76MD
 
 Required: python3 + xxhash. On vrs.com the default python3 is 3.6 and
 fails to open the 9 GB Zip64 source, so use python3.12 (which needed
@@ -123,7 +141,51 @@ def xxhash_file(path):
     return h.hexdigest()
 
 
-def build_zip(src, by_folder, aircraft, cockpit, out):
+def _collect_from_zip(src):
+    """Index a monolithic Liveries.zip by top-level Liveries/<folder>/.
+
+    Returns {src_folder: [(filename, is_dir, ref)]} where ref is the
+    ZipInfo (read lazily via the reader closure in main).
+    """
+    by_folder = {}
+    for e in src.infolist():
+        parts = e.filename.split("/", 2)
+        if len(parts) < 2 or parts[0] != "Liveries":
+            continue
+        src_folder = parts[1]
+        by_folder.setdefault(src_folder, []).append(
+            (e.filename, e.is_dir(), e)
+        )
+    return by_folder
+
+
+def _collect_from_dir(source_dir):
+    """Index a ~/livery-source/<folder>/<slug>/... tree.
+
+    Synthesizes `Liveries/<folder>/<slug>/<rest>` filenames so the
+    downstream build_zip logic is shared with the zip-source path.
+    Returns {src_folder: [(filename, is_dir, ref)]} where ref is the
+    Path on disk (read lazily by the reader closure).
+    """
+    by_folder = {}
+    for src_folder_path in sorted(source_dir.iterdir()):
+        if not src_folder_path.is_dir():
+            continue
+        src_folder = src_folder_path.name
+        entries = []
+        for path in sorted(src_folder_path.rglob("*")):
+            rel = path.relative_to(src_folder_path).as_posix()
+            synthetic = f"Liveries/{src_folder}/{rel}"
+            if path.is_dir():
+                entries.append((synthetic + "/", True, path))
+            elif path.is_file():
+                entries.append((synthetic, False, path))
+        if entries:
+            by_folder[src_folder] = entries
+    return by_folder
+
+
+def build_zip(by_folder, reader, aircraft, cockpit, out):
     """Write one per-aircraft zip with the 2-layer wrapper structure."""
     if out.exists():
         out.unlink()
@@ -134,11 +196,11 @@ def build_zip(src, by_folder, aircraft, cockpit, out):
     with zipfile.ZipFile(out, "w", zipfile.ZIP_STORED) as dst:
         for target in [aircraft] + ([cockpit] if cockpit else []):
             for src_folder in sources_for(target):
-                for e in by_folder.get(src_folder, []):
+                for filename, is_dir, ref in by_folder.get(src_folder, []):
                     # Inner path -- the install-relative path that ends
                     # up inside Saved Games/DCS/ after OMM strips the
                     # outer wrapper.
-                    inner = e.filename.replace(
+                    inner = filename.replace(
                         f"Liveries/{src_folder}/",
                         f"Liveries/{target}/",
                         1,
@@ -154,11 +216,10 @@ def build_zip(src, by_folder, aircraft, cockpit, out):
                             collisions.append(f"{src_folder} -> {target}: {new_name}")
                         continue
                     seen.add(new_name)
-                    data = src.read(e)
-                    if e.is_dir():
+                    if is_dir:
                         dst.writestr(new_name.rstrip("/") + "/", b"")
                     else:
-                        dst.writestr(new_name, data)
+                        dst.writestr(new_name, reader(ref))
                     total_entries += 1
     if collisions:
         print(f"  COLLISIONS in {out.name} ({len(collisions)} skipped):")
@@ -169,6 +230,54 @@ def build_zip(src, by_folder, aircraft, cockpit, out):
     return total_entries
 
 
+def _build_all(by_folder, reader, out_dir, wanted_aircraft):
+    """Build per-aircraft zips. wanted_aircraft=None means all 22."""
+    if wanted_aircraft:
+        wanted = set(wanted_aircraft)
+        unknown = wanted - {a for a, _ in AIRCRAFT}
+        if unknown:
+            sys.exit(f"unknown aircraft: {sorted(unknown)}")
+        aircraft_list = [(a, c) for (a, c) in AIRCRAFT if a in wanted]
+    else:
+        aircraft_list = AIRCRAFT
+
+    results = {}
+    for aircraft, cockpit in aircraft_list:
+        out = out_dir / f"{aircraft}.zip"
+        print(f"building {aircraft}.zip ...")
+        n = build_zip(by_folder, reader, aircraft, cockpit, out)
+        if n == 0:
+            print(f"  WARN: {aircraft}.zip would be empty -- skipping")
+            if out.exists():
+                out.unlink()
+            continue
+        bytes_ = out.stat().st_size
+        xxhsum = xxhash_file(out)
+        results[aircraft] = {"bytes": bytes_, "xxhsum": xxhsum}
+        print(f"  -> {n:>5} entries  {bytes_:>12,} bytes  {xxhsum}")
+    return results
+
+
+def _write_manifest(out_dir, results, incremental):
+    """Write manifest.json. If incremental, merge results into existing."""
+    manifest_path = out_dir / "manifest.json"
+    if incremental and manifest_path.exists():
+        existing = json.loads(manifest_path.read_text(encoding="utf-8"))
+        merged = dict(existing.get("aircraft", {}))
+        merged.update(results)
+        results = merged
+    manifest = {
+        "built_at": datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
+        "aircraft": results,
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+    return manifest_path
+
+
 def main():
     home = Path.home()
     parser = argparse.ArgumentParser(description=__doc__)
@@ -176,7 +285,7 @@ def main():
         "--source",
         type=Path,
         default=home / "public_html" / "Mods" / "Liveries.zip",
-        help="Monolithic Liveries.zip to read from",
+        help="Monolithic Liveries.zip OR ~/livery-source/ directory",
     )
     parser.add_argument(
         "--out",
@@ -184,46 +293,37 @@ def main():
         default=home / "public_html" / "Mods" / "Liveries",
         help="Directory to write per-aircraft <Aircraft>.zip + manifest.json into",
     )
+    parser.add_argument(
+        "--aircraft",
+        action="append",
+        metavar="NAME",
+        help="Restrict build to this aircraft (may be repeated). "
+             "manifest.json is merged rather than replaced.",
+    )
     args = parser.parse_args()
 
-    if not args.source.is_file():
-        sys.exit(f"missing source zip: {args.source}")
     args.out.mkdir(parents=True, exist_ok=True)
 
-    print(f"opening {args.source} ...")
-    with zipfile.ZipFile(args.source, "r") as src:
-        entries = src.infolist()
-        print(f"  {len(entries):,} entries in source zip")
-
-        by_folder = {}
-        for e in entries:
-            parts = e.filename.split("/", 2)
-            if len(parts) < 2 or parts[0] != "Liveries":
-                continue
-            by_folder.setdefault(parts[1], []).append(e)
+    if args.source.is_file() and args.source.suffix.lower() == ".zip":
+        print(f"opening zip source: {args.source}")
+        with zipfile.ZipFile(args.source, "r") as src:
+            print(f"  {len(src.infolist()):,} entries in source")
+            by_folder = _collect_from_zip(src)
+            print(f"  {len(by_folder)} top-level folders\n")
+            reader = src.read
+            results = _build_all(by_folder, reader, args.out, args.aircraft)
+    elif args.source.is_dir():
+        print(f"reading dir source: {args.source}")
+        by_folder = _collect_from_dir(args.source)
         print(f"  {len(by_folder)} top-level folders\n")
+        reader = lambda ref: ref.read_bytes()
+        results = _build_all(by_folder, reader, args.out, args.aircraft)
+    else:
+        sys.exit(f"--source not found or not a zip/dir: {args.source}")
 
-        results = {}
-        for aircraft, cockpit in AIRCRAFT:
-            out = args.out / f"{aircraft}.zip"
-            print(f"building {aircraft}.zip ...")
-            n = build_zip(src, by_folder, aircraft, cockpit, out)
-            if n == 0:
-                print(f"  WARN: {aircraft}.zip would be empty -- skipping")
-                if out.exists():
-                    out.unlink()
-                continue
-            bytes_ = out.stat().st_size
-            xxhsum = xxhash_file(out)
-            results[aircraft] = {"bytes": bytes_, "xxhsum": xxhsum}
-            print(f"  -> {n:>5} entries  {bytes_:>12,} bytes  {xxhsum}")
-
-    manifest_path = args.out / "manifest.json"
-    manifest = {
-        "built_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "aircraft": results,
-    }
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    manifest_path = _write_manifest(
+        args.out, results, incremental=bool(args.aircraft)
+    )
     print(f"\nwrote {manifest_path}")
 
 

--- a/scripts/extract-livery-source.py
+++ b/scripts/extract-livery-source.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""One-shot migration: extract Liveries.zip into ~/livery-source/.
+
+The resulting tree is the source-of-truth for the Phase 2c+ rebuild
+flow. After this runs, build-aircraft-packs.py can be invoked with
+`--source ~/livery-source` to rebuild per-aircraft zips. publish.py
+SSH-pushes new livery slugs into this tree and triggers an
+incremental rebuild.
+
+Layout after extraction:
+
+    ~/livery-source/
+      <src_folder>/                  # pre-RENAME folder name
+        <slug>/                      # livery folder
+          description.lua
+          *.dds
+          ...
+
+The RENAME map in build-aircraft-packs.py is applied at zip-time, so
+src_folder names like `il-76md` and `F-16C` stay as-is here but end
+up rewritten inside the published zips.
+
+Run once on vrs.com:
+
+    python3.12 ~/bin/extract-livery-source.py
+
+Disk: extracting the current 9.7 GB monolith produces ~25 GB on disk
+(uncompressed; DDS textures dominate). Check `df -h ~` first.
+"""
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+DEFAULT_SOURCE = Path.home() / "public_html" / "Mods" / "Liveries.zip"
+DEFAULT_OUT = Path.home() / "livery-source"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would be written; don't touch disk."
+    )
+    args = parser.parse_args()
+
+    if not args.source.is_file():
+        sys.exit(f"source not found: {args.source}")
+    if args.out.exists() and any(args.out.iterdir()):
+        sys.exit(
+            f"refusing to extract into non-empty directory: {args.out}\n"
+            f"if intentional, mv it aside first."
+        )
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    print(f"opening {args.source} ...")
+    written = 0
+    skipped = 0
+    bytes_ = 0
+    with zipfile.ZipFile(args.source, "r") as src:
+        entries = src.infolist()
+        print(f"  {len(entries):,} entries in source")
+        for e in entries:
+            name = e.filename
+            if not name.startswith("Liveries/"):
+                skipped += 1
+                continue
+            rel = name[len("Liveries/"):]
+            if not rel or rel.endswith("/"):
+                continue
+            if ".." in rel.split("/"):
+                skipped += 1
+                continue
+            out_path = args.out / rel
+            if args.dry_run:
+                if written < 5:
+                    print(f"  would write {out_path}")
+                written += 1
+                continue
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            with src.open(e) as fsrc, open(out_path, "wb") as fdst:
+                while True:
+                    chunk = fsrc.read(1 << 20)
+                    if not chunk:
+                        break
+                    fdst.write(chunk)
+                    bytes_ += len(chunk)
+            written += 1
+            if written % 1000 == 0:
+                print(f"  ...{written:,} files ({bytes_ / 1024**3:.2f} GiB)")
+    print(
+        f"done. wrote {written:,} files ({bytes_ / 1024**3:.2f} GiB), "
+        f"skipped {skipped}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scanner/publish.py
+++ b/scripts/scanner/publish.py
@@ -1,76 +1,333 @@
-"""Phase 2 publish stub: called by scan-livery.yml on PASS verdict.
+"""Phase 2c publish: push livery to vrs.com livery-source/, trigger
+rebuild, update pack.json + manifests, POST Discord embed.
 
-Real responsibilities (Phase 2c):
+Called by scan-livery.yml on a PASS verdict. Each step gracefully
+no-ops if its prerequisites are missing, so this script is safe to
+land before the user mints the secrets.
 
-  1. Read the verdict.json + the candidate livery zip.
-  2. Identify the target aircraft from the zip's top-level folder.
-  3. SSH push the livery content into
-     vrs.com:~/livery-source/<Aircraft>/<slug>/
-  4. Rebuild ONLY the affected <Aircraft>.zip
-     (`~/bin/build-aircraft-packs.py --only <Aircraft>`).
-  5. Compute the new bytes + xxhsum (returned by the rebuild script).
-  6. Update liveries-index/<Aircraft>/pack.json; commit + push.
-  7. Regenerate the three repo manifests
-     (`python scripts/build-repo.py`) and scp them to vrs.com.
-  8. POST a Discord embed to the #liveries webhook -- the published
-     livery + uploader handle + preview thumbnail (if `preview.jpg`
-     was supplied in the upload).
+Steps and their prereqs:
 
-For Phase 2b this script is a STUB. It reads the verdict + does
-basic inspection and emits a structured summary to
-$GITHUB_STEP_SUMMARY so the workflow run page is useful. The real
-SSH + git + Discord work is deferred until:
+  1. Parse zip layout -> (aircraft, slugs).
+     No prereqs.
 
-  - The dedicated ed25519 SSH key is minted and added as
-    secrets.VRS_SSH_KEY with `command=` restriction on vrs.com.
-  - The Discord webhook URL is added as
-    secrets.DISCORD_LIVERIES_WEBHOOK.
-  - A fine-grained GitHub PAT is configured for the actions
-    runner to commit pack.json updates back to main.
+  2. Stage slug content to /tmp/livery-extract/.
+     No prereqs.
 
-When any of those is missing, the stub logs that it would have
-done X and exits 0.
+  3. Rsync each slug to vrs.com:~/livery-source/<dest>/<slug>/
+     where <dest> is <Aircraft> for external liveries or
+     Cockpit_<Aircraft> for cockpit liveries.
+     Prereq: VRS_SSH_KEY env var (private key, multiline).
+
+  4. Trigger rebuild on vrs.com:
+       python3.12 ~/bin/build-aircraft-packs.py --aircraft <Aircraft>
+     Prereq: SSH key + rebuild script with --aircraft support
+     deployed on vrs.com (see scripts/build-aircraft-packs.py).
+
+  5. SCP manifest.json back, read bytes + xxhsum for <Aircraft>.
+     Prereq: rebuild succeeded.
+
+  6. Update liveries-index/<Aircraft>/pack.json locally (no commit yet).
+
+  7. Re-run scripts/build-repo.py to regenerate the 3 manifests.
+
+  8. SCP manifests to vrs.com (VRSInstall.xml + VRSSavedGames.xml at
+     public_html/, repo.xml at Mods/).
+     Prereq: SSH key.
+
+  9. Commit + push pack.json (LAST so that if branch protection
+     rejects the push, vrs.com state is still consistent and only
+     the repo's pack.json drifts from main).
+     Prereq: workflow has contents:write (set on the job) AND
+     branch protection allows github-actions[bot] to push, OR a
+     PR-based recovery is acceptable. The default GITHUB_TOKEN
+     does NOT bypass branch protection -- if main requires PRs,
+     the user must add github-actions[bot] to "Allow specified
+     actors to bypass" or restructure to auto-PR flow.
+
+  10. POST Discord embed to #liveries webhook.
+      Prereq: DISCORD_LIVERIES_WEBHOOK env var.
+
+If a step's prereq is missing, the script logs why and stops at that
+point (or skips to Discord if reasonable). The final summary states
+what ran and what was skipped.
 """
 
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import os
+import shutil
+import subprocess
 import sys
+import urllib.error
+import urllib.request
 import zipfile
 from pathlib import Path
 
+SSH_KEY_PATH = Path("/tmp/vrs-ssh-key")
+SSH_KNOWN_HOSTS = Path("/tmp/vrs-known-hosts")
+EXTRACT_ROOT = Path("/tmp/livery-extract")
+REMOTE_MANIFEST_LOCAL = Path("/tmp/vrs-new-manifest.json")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ----- layout parsing ------------------------------------------------
+
+
+def _parse_layout(zip_path: Path) -> tuple[str, list[tuple[str, str, str]]]:
+    """Identify aircraft + slugs in the candidate zip.
+
+    Returns (aircraft, slugs) where each slug entry is
+    (dest_folder, slug_name, zip_prefix):
+      - dest_folder: <Aircraft> or Cockpit_<Aircraft> (rsync destination)
+      - slug_name: livery folder name
+      - zip_prefix: prefix in zip to strip when extracting this slug
+
+    Supports both layouts:
+      - Single-livery upload: <Aircraft>/<slug>/...
+      - Full-pack (test corpus): <Aircraft>/Liveries/<dest>/<slug>/...
+        where <dest> is <Aircraft> or Cockpit_<Aircraft>.
+    """
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        names = [info.filename for info in zf.infolist() if not info.is_dir()]
+    if not names:
+        raise ValueError("empty zip")
+
+    tops = {n.split("/", 1)[0] for n in names if "/" in n}
+    if len(tops) != 1:
+        raise ValueError(f"expected one top folder, got: {sorted(tops)}")
+    aircraft = next(iter(tops))
+
+    full_pack_prefix = f"{aircraft}/Liveries/"
+    is_full_pack = any(n.startswith(full_pack_prefix) for n in names)
+
+    slugs: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    if is_full_pack:
+        for n in names:
+            parts = n.split("/")
+            if (
+                len(parts) < 5
+                or parts[0] != aircraft
+                or parts[1] != "Liveries"
+            ):
+                continue
+            dest_folder, slug_name = parts[2], parts[3]
+            if not dest_folder or not slug_name:
+                continue
+            key = (dest_folder, slug_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            slugs.append(
+                (
+                    dest_folder,
+                    slug_name,
+                    f"{aircraft}/Liveries/{dest_folder}/{slug_name}/",
+                )
+            )
+    else:
+        for n in names:
+            parts = n.split("/")
+            if len(parts) < 3 or parts[0] != aircraft:
+                continue
+            slug_name = parts[1]
+            if not slug_name:
+                continue
+            key = (aircraft, slug_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            slugs.append((aircraft, slug_name, f"{aircraft}/{slug_name}/"))
+
+    return aircraft, slugs
+
+
+def _extract_slug(zip_path: Path, slug: tuple[str, str, str], out_dir: Path) -> int:
+    """Extract one slug's content into out_dir/<slug_name>/.
+
+    The zip_prefix is stripped. Skips any entry containing `..` as a
+    defense-in-depth check (the scanner should already have rejected
+    path traversal, but a publish.py that blindly trusts the scanner
+    is one bug away from RCE).
+    Returns the number of files written.
+    """
+    dest_folder, slug_name, prefix = slug
+    target = out_dir / slug_name
+    target.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        for info in zf.infolist():
+            if not info.filename.startswith(prefix) or info.is_dir():
+                continue
+            rel = info.filename[len(prefix):]
+            if not rel or rel.endswith("/"):
+                continue
+            if ".." in rel.split("/"):
+                continue
+            out_path = target / rel
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as src, open(out_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            count += 1
+    return count
+
+
+# ----- SSH helpers ---------------------------------------------------
+
+
+def _ssh_setup() -> Path | None:
+    """Materialize VRS_SSH_KEY into a temp file with 0600 perms."""
+    key = os.environ.get("VRS_SSH_KEY", "").strip()
+    if not key:
+        return None
+    if not key.endswith("\n"):
+        key += "\n"
+    SSH_KEY_PATH.write_text(key, encoding="utf-8")
+    SSH_KEY_PATH.chmod(0o600)
+    SSH_KNOWN_HOSTS.touch(exist_ok=True)
+    SSH_KNOWN_HOSTS.chmod(0o600)
+    return SSH_KEY_PATH
+
+
+def _ssh_opts(key_path: Path) -> list[str]:
+    return [
+        "-i", str(key_path),
+        "-o", f"UserKnownHostsFile={SSH_KNOWN_HOSTS}",
+        "-o", "BatchMode=yes",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ServerAliveInterval=30",
+    ]
+
+
+def _ssh_exec(host: str, key_path: Path, cmd: str, timeout: int = 300) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["ssh", *_ssh_opts(key_path), host, cmd],
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def _rsync_to(local_dir: Path, host: str, remote_dir: str, key_path: Path) -> subprocess.CompletedProcess:
+    ssh_e = "ssh " + " ".join(_ssh_opts(key_path))
+    return subprocess.run(
+        ["rsync", "-az", "--mkpath", "-e", ssh_e,
+         f"{local_dir}/", f"{host}:{remote_dir}/"],
+        capture_output=True, text=True, timeout=900,
+    )
+
+
+def _scp_to(local: Path, host: str, remote: str, key_path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["scp", *_ssh_opts(key_path), str(local), f"{host}:{remote}"],
+        capture_output=True, text=True, timeout=120,
+    )
+
+
+def _scp_from(host: str, remote: str, local: Path, key_path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["scp", *_ssh_opts(key_path), f"{host}:{remote}", str(local)],
+        capture_output=True, text=True, timeout=120,
+    )
+
+
+# ----- git, manifests, Discord --------------------------------------
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True
+    )
+
+
+def _commit_and_push(repo: Path, file_rel: str, message: str) -> tuple[bool, str]:
+    actor = os.environ.get("GITHUB_ACTOR", "github-actions[bot]")
+    email = f"{actor}@users.noreply.github.com"
+    _git(repo, "config", "user.name", actor)
+    _git(repo, "config", "user.email", email)
+    _git(repo, "add", file_rel)
+    diff = _git(repo, "diff", "--cached", "--name-only").stdout.strip()
+    if not diff:
+        return True, "no-op (pack.json unchanged)"
+    commit = _git(repo, "commit", "-m", message)
+    if commit.returncode != 0:
+        return False, f"commit failed: {commit.stderr.strip()[:200]}"
+    push = _git(repo, "push", "origin", "HEAD:main")
+    if push.returncode != 0:
+        return False, f"push failed: {push.stderr.strip()[:200]}"
+    return True, "pushed"
+
+
+def _regen_manifests(repo: Path) -> tuple[bool, str]:
+    proc = subprocess.run(
+        [sys.executable, "scripts/build-repo.py"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return False, proc.stderr.strip()[:500]
+    return True, ""
+
+
+def _http_post(url: str, payload: dict) -> tuple[int, str]:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.status, resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", errors="replace")
+    except Exception as e:  # noqa: BLE001
+        return -1, f"{type(e).__name__}: {e}"
+
+
+def _discord_embed(aircraft: str, slugs: list[tuple[str, str, str]], verdict: dict, published: bool) -> dict:
+    slug_list = ", ".join(f"`{s[1]}`" for s in slugs[:10])
+    if len(slugs) > 10:
+        slug_list += f" _and {len(slugs) - 10} more_"
+    title = "New livery published" if published else "Livery scan completed"
+    color = 3066993 if published else 10070709  # green / gray
+    return {
+        "embeds": [{
+            "title": title,
+            "description": (
+                f"**{aircraft}** -- by **"
+                f"{os.environ.get('UPLOADER_EMAIL', 'unknown')}**"
+            ),
+            "color": color,
+            "fields": [
+                {"name": "Liveries", "value": slug_list or "_(none)_", "inline": False},
+                {"name": "Sample sha256", "value": f"`{verdict['sample']['sha256'][:16]}...`", "inline": True},
+                {"name": "Bytes", "value": f"{verdict['sample']['bytes']:,}", "inline": True},
+            ],
+            "footer": {"text": "OMM users auto-update on next launch."},
+        }],
+    }
+
 
 def _github_summary(text: str) -> None:
-    """Append to the GHA run-page summary if running in Actions."""
-    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-    if not summary_path:
+    p = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not p:
         return
-    with open(summary_path, "a", encoding="utf-8") as f:
+    with open(p, "a", encoding="utf-8") as f:
         f.write(text)
         if not text.endswith("\n"):
             f.write("\n")
 
 
-def _identify_aircraft(zip_path: Path) -> str | None:
-    """Find the aircraft name from the zip's top-level folder.
+def _emit(lines: list[str]) -> None:
+    text = "\n".join(lines) + "\n"
+    print(text)
+    _github_summary(text)
 
-    Per the Phase 1 OvGME convention, livery zips have outer
-    structure `<Aircraft>/Liveries/<Aircraft>/<livery>/...`. The
-    outer folder is the aircraft. For uploaded liveries that
-    haven't been wrapped yet, the structure may be just
-    `<Aircraft>/<livery>/...` -- same answer.
-    """
-    with zipfile.ZipFile(zip_path, "r") as zf:
-        roots = set()
-        for info in zf.infolist():
-            parts = info.filename.replace("\\", "/").split("/", 1)
-            if parts and parts[0]:
-                roots.add(parts[0])
-    if len(roots) == 1:
-        return roots.pop()
-    return None
+
+# ----- main flow -----------------------------------------------------
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -80,40 +337,214 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     verdict = json.loads(args.verdict.read_text(encoding="utf-8"))
-    aircraft = _identify_aircraft(args.zip)
-
-    have_ssh = bool(os.environ.get("VRS_SSH_KEY"))
-    have_webhook = bool(os.environ.get("DISCORD_LIVERIES_WEBHOOK"))
+    host = os.environ.get("VRS_SSH_HOST", "customdc@vrs.com")
 
     lines = [
-        "## Publish (stub)",
+        "## Publish",
         "",
-        f"- **Verdict:** PASS",
-        f"- **Aircraft:** `{aircraft or 'unknown'}`",
+        "- **Verdict:** PASS",
         f"- **Sample sha256:** `{verdict['sample']['sha256']}`",
         f"- **Sample bytes:** {verdict['sample']['bytes']:,}",
         f"- **Uploader:** {os.environ.get('UPLOADER_EMAIL', 'unknown')} "
         f"(id {os.environ.get('UPLOADER_ID', '?')})",
         f"- **Original filename:** `{os.environ.get('ORIGINAL_FILENAME', '?')}`",
         "",
-        "### What this stub would do (Phase 2c):",
-        "",
-        "1. SSH push to `vrs.com:~/livery-source/" + (aircraft or "<Aircraft>") + "/<slug>/`",
-        "2. Rebuild `" + (aircraft or "<Aircraft>") + ".zip` on vrs.com",
-        "3. Update `liveries-index/" + (aircraft or "<Aircraft>") + "/pack.json` + git push",
-        "4. Regenerate + scp the three repo manifests",
-        "5. POST Discord embed to `#liveries`",
-        "",
-        "### Secrets available in this run:",
-        "",
-        f"- VRS_SSH_KEY: {'set' if have_ssh else '**NOT SET**'}",
-        f"- DISCORD_LIVERIES_WEBHOOK: {'set' if have_webhook else '**NOT SET**'}",
     ]
-    summary = "\n".join(lines) + "\n"
 
-    print(summary)
-    _github_summary(summary)
-    return 0
+    # 1. parse layout
+    try:
+        aircraft, slugs = _parse_layout(args.zip)
+    except Exception as e:  # noqa: BLE001
+        lines.append(f"- **ERROR** parsing layout: `{e}`")
+        _emit(lines)
+        return 1
+
+    lines.append(f"- **Aircraft:** `{aircraft}`")
+    lines.append(f"- **Slugs to publish:** {len(slugs)}")
+    for dest, slug_name, _ in slugs[:20]:
+        lines.append(f"  - `{dest}/{slug_name}`")
+    if len(slugs) > 20:
+        lines.append(f"  - _and {len(slugs) - 20} more_")
+    lines.append("")
+
+    # 2. stage extraction
+    if EXTRACT_ROOT.exists():
+        shutil.rmtree(EXTRACT_ROOT)
+    EXTRACT_ROOT.mkdir(parents=True)
+    by_dest: dict[str, list[str]] = {}
+    for slug in slugs:
+        dest_folder, slug_name, _prefix = slug
+        n = _extract_slug(args.zip, slug, EXTRACT_ROOT / dest_folder)
+        by_dest.setdefault(dest_folder, []).append(slug_name)
+        if n == 0:
+            lines.append(f"- WARN: no files extracted for `{dest_folder}/{slug_name}`")
+
+    # 3. SSH key
+    key_path = _ssh_setup()
+    if not key_path:
+        lines.append("### SSH push: **SKIPPED** (VRS_SSH_KEY not set)")
+        lines.append("")
+        lines.append("Steps 3-8 require the dedicated ed25519 key on vrs.com. ")
+        lines.append("See PLAN.md Phase 2 starting position for the secrets checklist.")
+        _emit(lines)
+        return 0
+    lines.append(f"- **SSH host:** `{host}`")
+    lines.append("")
+
+    # 4. rsync slugs to ~/livery-source/<dest>/<slug>/
+    lines.append("### Rsync slugs to vrs.com:~/livery-source/")
+    rsync_ok = True
+    for dest_folder, slug_names in by_dest.items():
+        local_dir = EXTRACT_ROOT / dest_folder
+        remote_dir = f"livery-source/{dest_folder}"
+        proc = _rsync_to(local_dir, host, remote_dir, key_path)
+        if proc.returncode != 0:
+            lines.append(f"- FAIL `{dest_folder}` -> `{remote_dir}` (rc={proc.returncode})")
+            lines.append(f"  ```")
+            lines.append(f"  {proc.stderr.strip()[:800]}")
+            lines.append(f"  ```")
+            rsync_ok = False
+        else:
+            joined = ", ".join(f"`{s}`" for s in slug_names)
+            lines.append(f"- OK `{dest_folder}/`: {joined}")
+    lines.append("")
+    if not rsync_ok:
+        _emit(lines)
+        return 1
+
+    # 5. trigger rebuild on vrs.com
+    lines.append("### Rebuild on vrs.com")
+    rebuild_cmd = (
+        f"python3.12 ~/bin/build-aircraft-packs.py "
+        f"--aircraft {aircraft} "
+        f"--source ~/livery-source "
+        f"--out ~/public_html/Mods/Liveries"
+    )
+    proc = _ssh_exec(host, key_path, rebuild_cmd, timeout=900)
+    lines.append(f"- rc=`{proc.returncode}`")
+    if proc.stdout.strip():
+        lines.append("- stdout:")
+        lines.append("  ```")
+        lines.append(f"  {proc.stdout.strip()[:1500]}")
+        lines.append("  ```")
+    if proc.returncode != 0:
+        lines.append("- stderr:")
+        lines.append("  ```")
+        lines.append(f"  {proc.stderr.strip()[:1500]}")
+        lines.append("  ```")
+        lines.append("")
+        lines.append("(Likely cause: build-aircraft-packs.py on vrs.com lacks ")
+        lines.append("`--aircraft` mode. Deploy the updated script from ")
+        lines.append("`scripts/build-aircraft-packs.py` to `~/bin/` on vrs.com.)")
+        _emit(lines)
+        return 1
+    lines.append("")
+
+    # 6. fetch manifest.json
+    lines.append("### Fetch new manifest.json")
+    if REMOTE_MANIFEST_LOCAL.exists():
+        REMOTE_MANIFEST_LOCAL.unlink()
+    proc = _scp_from(host, "public_html/Mods/Liveries/manifest.json", REMOTE_MANIFEST_LOCAL, key_path)
+    if proc.returncode != 0 or not REMOTE_MANIFEST_LOCAL.exists():
+        lines.append(f"- FAIL: rc={proc.returncode}, {proc.stderr.strip()[:300]}")
+        _emit(lines)
+        return 1
+    manifest = json.loads(REMOTE_MANIFEST_LOCAL.read_text(encoding="utf-8"))
+    new_data = manifest.get("aircraft", {}).get(aircraft, {})
+    if not new_data or "bytes" not in new_data or "xxhsum" not in new_data:
+        lines.append(f"- FAIL: manifest missing entry for `{aircraft}`")
+        _emit(lines)
+        return 1
+    new_bytes = new_data["bytes"]
+    new_xxhsum = new_data["xxhsum"]
+    lines.append(f"- new bytes: {new_bytes:,}")
+    lines.append(f"- new xxhsum: `{new_xxhsum}`")
+    lines.append("")
+
+    # 7. update pack.json LOCALLY (no commit yet -- regen + scp first so
+    #    if git push fails later, the user-visible state on vrs.com is
+    #    consistent: new zip + new manifests pointing to new xxhsum. The
+    #    only drift is then repo pack.json vs origin/main, recoverable
+    #    by re-running with a green push or by a manual PR.
+    lines.append("### Update pack.json (local)")
+    pack_path = REPO_ROOT / "liveries-index" / aircraft / "pack.json"
+    if not pack_path.exists():
+        lines.append(f"- FAIL: `{pack_path.relative_to(REPO_ROOT)}` not found")
+        _emit(lines)
+        return 1
+    pack = json.loads(pack_path.read_text(encoding="utf-8"))
+    old_xxhsum = pack.get("xxhsum")
+    pack["bytes"] = new_bytes
+    pack["xxhsum"] = new_xxhsum
+    pack["last_built_at"] = datetime.datetime.now(
+        datetime.timezone.utc
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    pack_path.write_text(json.dumps(pack, indent=2) + "\n", encoding="utf-8")
+    lines.append(f"- xxhsum: `{old_xxhsum}` -> `{new_xxhsum}`")
+    lines.append("")
+
+    # 8. regen + scp manifests (BEFORE git push -- see ordering note above)
+    lines.append("### Regenerate + deploy manifests")
+    ok, err = _regen_manifests(REPO_ROOT)
+    if not ok:
+        lines.append(f"- build-repo.py FAIL: {err}")
+        _emit(lines)
+        return 1
+    lines.append("- regenerated Release/{VRSInstall,VRSSavedGames,repo}.xml")
+    release_dir = REPO_ROOT / "Release"
+    scp_ok = True
+    for local_name, remote in [
+        ("VRSInstall.xml", "public_html/VRSInstall.xml"),
+        ("VRSSavedGames.xml", "public_html/VRSSavedGames.xml"),
+        ("repo.xml", "public_html/Mods/repo.xml"),
+    ]:
+        proc = _scp_to(release_dir / local_name, host, remote, key_path)
+        if proc.returncode != 0:
+            lines.append(f"- FAIL `{local_name}` -> `{remote}`: rc={proc.returncode}")
+            scp_ok = False
+        else:
+            lines.append(f"- OK   `{local_name}` -> `{remote}`")
+    lines.append("")
+
+    # 9. commit + push pack.json. If branch protection rejects, the
+    #    user-visible state on vrs.com is still consistent (step 8 ran);
+    #    only the repo's pack.json drifts from main. The publish_failed
+    #    flag below ensures the run is marked failed so the user sees it.
+    lines.append("### Commit + push pack.json")
+    sha_short = verdict["sample"]["sha256"][:12]
+    git_ok, git_msg = _commit_and_push(
+        REPO_ROOT,
+        f"liveries-index/{aircraft}/pack.json",
+        f"Liveries ({aircraft}): publish via scan-livery ({sha_short})",
+    )
+    lines.append(f"- git: {'OK' if git_ok else 'FAIL'} -- {git_msg}")
+    if not git_ok:
+        lines.append("")
+        lines.append(
+            "**Heads-up:** vrs.com state is consistent (sub-pack + "
+            "manifests deployed) but the repo's `liveries-index/"
+            f"{aircraft}/pack.json` is now out of sync with `main`. "
+            "Recover by opening a PR with the local pack.json changes, "
+            "or check branch protection on `main` (Settings -> Branches) "
+            "to allow `github-actions[bot]` to bypass."
+        )
+    lines.append("")
+
+    # 10. Discord embed
+    lines.append("### Discord #liveries")
+    webhook = os.environ.get("DISCORD_LIVERIES_WEBHOOK", "").strip()
+    if not webhook:
+        lines.append("- SKIPPED (DISCORD_LIVERIES_WEBHOOK not set)")
+    else:
+        payload = _discord_embed(aircraft, slugs, verdict, published=True)
+        code, body = _http_post(webhook, payload)
+        lines.append(f"- POST status: `{code}`")
+        if body and code not in (200, 204):
+            lines.append(f"  body: `{body[:200]}`")
+    lines.append("")
+
+    _emit(lines)
+    return 0 if (scp_ok and git_ok) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/scanner/reject.py
+++ b/scripts/scanner/reject.py
@@ -1,36 +1,38 @@
-"""Phase 2 reject stub: called by scan-livery.yml on FAIL verdict.
+"""Phase 2c reject: called by scan-livery.yml on a FAIL verdict.
 
-Real responsibilities (Phase 2c):
-
-  1. POST a Discord embed to the staff on-call channel:
-       <@&ONCALL_ROLE_ID> Upload from <uploader> rejected
-       Reason codes: lua_disallowed_call:os.execute, ...
-       SHA256: <hex>
-       Quarantined at vrs.com:~/quarantine/<sha256>/
-  2. POST an HMAC-signed payload to vrs.com:
-       /_internal/livery-flag.php  { sha256, reasons, verdict }
+  1. POST a Discord embed to the staff on-call channel with the
+     uploader's email, the rejection reasons, and the sha256 of
+     the quarantined sample on vrs.com.
+  2. POST an HMAC-SHA256-signed payload to
+       https://victorromeosierra.com/_internal/livery-flag.php
+       { sha256, verdict, reasons, ts }
      which writes a REJECTED.json next to the raw upload in
      ~/quarantine/<sha256>/ so future tooling can list rejections.
+     The endpoint itself lands in Phase 3 (it needs the ProjectSend
+     cron to first quarantine samples). This script is wire-ready;
+     it no-ops the POST gracefully when VRS_WEBHOOK_KEY isn't set.
 
 The bad uploader is INTENTIONALLY not notified -- per PLAN.md
 Component 5c, no feedback loop for crafting bypasses; staff
 handles the human side on Discord.
-
-For Phase 2b this is a STUB. It assembles the would-be Discord
-embed payload, logs it to the GHA step summary, and POSTs to
-DISCORD_STAFF_WEBHOOK if that secret is set. The vrs.com
-quarantine webhook is deferred until Phase 3 (it needs the
-ProjectSend cron to first land samples in ~/quarantine/).
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
+import hmac
 import json
 import os
 import sys
+import time
+import urllib.error
 import urllib.request
 from pathlib import Path
+
+QUARANTINE_WEBHOOK_URL = (
+    "https://victorromeosierra.com/_internal/livery-flag.php"
+)
 
 
 def _github_summary(text: str) -> None:
@@ -95,21 +97,55 @@ def _build_discord_embed(verdict: dict) -> dict:
     }
 
 
-def _post_discord(webhook_url: str, payload: dict) -> tuple[int, str]:
-    body = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        webhook_url,
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
+def _http_post(url: str, body: bytes, headers: dict[str, str]) -> tuple[int, str]:
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             return resp.status, resp.read().decode("utf-8", errors="replace")
     except urllib.error.HTTPError as e:
         return e.code, e.read().decode("utf-8", errors="replace")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return -1, f"{type(e).__name__}: {e}"
+
+
+def _post_discord(webhook_url: str, payload: dict) -> tuple[int, str]:
+    body = json.dumps(payload).encode("utf-8")
+    return _http_post(
+        webhook_url, body, {"Content-Type": "application/json"}
+    )
+
+
+def _post_quarantine_flag(verdict: dict, hmac_key: str) -> tuple[int, str]:
+    """POST an HMAC-signed verdict to vrs.com livery-flag.php.
+
+    Payload schema (also documented for the Phase 3 endpoint impl):
+
+        { "sha256":  "<hex>",
+          "verdict": "REJECT",
+          "reasons": ["lua_disallowed_call:os.execute", ...],
+          "ts":      <unix-seconds, integer> }
+
+    Signature: hex(HMAC-SHA256(key, body)) in X-VRS-Signature header.
+    Endpoint MUST reject if |now - ts| > 300s to bound replay window.
+    """
+    payload = {
+        "sha256": verdict["sample"]["sha256"],
+        "verdict": "REJECT",
+        "reasons": [f["reason"] for f in verdict["findings"]],
+        "ts": int(time.time()),
+    }
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    sig = hmac.new(
+        hmac_key.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+    return _http_post(
+        QUARANTINE_WEBHOOK_URL,
+        body,
+        {
+            "Content-Type": "application/json",
+            "X-VRS-Signature": sig,
+        },
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -151,11 +187,28 @@ def main(argv: list[str] | None = None) -> int:
         lines.append("")
         lines.append("### Discord POST")
         lines.append(f"- status: `{code}`")
-        if body:
+        if body and code not in (200, 204):
             lines.append(f"- body: `{body[:300]}`")
     else:
         lines.append("")
         lines.append("### Discord POST: **skipped** (DISCORD_STAFF_WEBHOOK not set)")
+
+    hmac_key = os.environ.get("VRS_WEBHOOK_KEY", "").strip()
+    if hmac_key:
+        code, body = _post_quarantine_flag(verdict, hmac_key)
+        lines.append("")
+        lines.append("### vrs.com quarantine flag POST")
+        lines.append(f"- url: `{QUARANTINE_WEBHOOK_URL}`")
+        lines.append(f"- status: `{code}`")
+        if body and code not in (200, 204):
+            lines.append(f"- body: `{body[:300]}`")
+    else:
+        lines.append("")
+        lines.append(
+            "### vrs.com quarantine flag POST: **skipped** "
+            "(VRS_WEBHOOK_KEY not set -- endpoint also doesn't exist "
+            "yet; lands in Phase 3)"
+        )
 
     summary = "\n".join(lines) + "\n"
     print(summary)

--- a/scripts/scanner/tests/test_publish.py
+++ b/scripts/scanner/tests/test_publish.py
@@ -1,0 +1,125 @@
+"""Layout parsing + extraction tests for publish.py.
+
+publish.py needs to recognize two zip shapes:
+
+  - **Single-livery upload** (ProjectSend production path):
+        <Aircraft>/<slug>/description.lua
+        <Aircraft>/<slug>/*.dds
+
+  - **Full-pack** (the test corpus shape, also what the user might
+    upload by mistake):
+        <Aircraft>/Liveries/<Aircraft>/<slug>/...
+        <Aircraft>/Liveries/Cockpit_<Aircraft>/<slug>/...
+
+Both must yield the right (aircraft, slugs) tuple and extract slug
+content with the zip-prefix stripped.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from scripts.scanner.publish import _parse_layout, _extract_slug
+
+
+def _build(zip_path: Path, files: dict[str, bytes]) -> Path:
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
+        for name, data in files.items():
+            zf.writestr(name, data)
+    return zip_path
+
+
+def test_single_livery_layout(tmp_path):
+    zp = _build(tmp_path / "single.zip", {
+        "FA-18C_hornet/VRS-001/description.lua": b"livery = {}\n",
+        "FA-18C_hornet/VRS-001/tex.dds": b"DDS \0\0\0\0",
+    })
+    aircraft, slugs = _parse_layout(zp)
+    assert aircraft == "FA-18C_hornet"
+    assert slugs == [("FA-18C_hornet", "VRS-001", "FA-18C_hornet/VRS-001/")]
+
+
+def test_full_pack_layout_external_only(tmp_path):
+    zp = _build(tmp_path / "fullpack-ext.zip", {
+        "IL-76MD/Liveries/IL-76MD/MD USSR/description.lua": b"livery = {}\n",
+        "IL-76MD/Liveries/IL-76MD/MD USSR/tex.dds": b"DDS \0\0\0\0",
+    })
+    aircraft, slugs = _parse_layout(zp)
+    assert aircraft == "IL-76MD"
+    assert slugs == [("IL-76MD", "MD USSR", "IL-76MD/Liveries/IL-76MD/MD USSR/")]
+
+
+def test_full_pack_layout_with_cockpit(tmp_path):
+    """Mi-8MT has both external + cockpit liveries; both must surface."""
+    zp = _build(tmp_path / "fullpack-mix.zip", {
+        "Mi-8MT/Liveries/Mi-8MT/Skin-A/description.lua": b"livery={}\n",
+        "Mi-8MT/Liveries/Cockpit_Mi-8MT/Cockpit-A/description.lua": b"livery={}\n",
+    })
+    aircraft, slugs = _parse_layout(zp)
+    assert aircraft == "Mi-8MT"
+    assert sorted(slugs) == [
+        ("Cockpit_Mi-8MT", "Cockpit-A", "Mi-8MT/Liveries/Cockpit_Mi-8MT/Cockpit-A/"),
+        ("Mi-8MT", "Skin-A", "Mi-8MT/Liveries/Mi-8MT/Skin-A/"),
+    ]
+
+
+def test_multiple_slugs_dedup(tmp_path):
+    """Two files in the same slug folder shouldn't yield two slug entries."""
+    zp = _build(tmp_path / "dup.zip", {
+        "A-10C_2/Skin-1/description.lua": b"livery={}\n",
+        "A-10C_2/Skin-1/tex.dds": b"DDS \0\0\0\0",
+        "A-10C_2/Skin-2/description.lua": b"livery={}\n",
+    })
+    aircraft, slugs = _parse_layout(zp)
+    assert aircraft == "A-10C_2"
+    assert sorted(slug for _, slug, _ in slugs) == ["Skin-1", "Skin-2"]
+
+
+def test_multiple_top_folders_rejected(tmp_path):
+    """A zip with two top folders is malformed for our pipeline."""
+    zp = _build(tmp_path / "two-tops.zip", {
+        "FA-18C_hornet/Skin/description.lua": b"livery={}\n",
+        "F-16C_50/Other/description.lua": b"livery={}\n",
+    })
+    try:
+        _parse_layout(zp)
+    except ValueError as e:
+        assert "one top folder" in str(e)
+    else:
+        raise AssertionError("expected ValueError on multi-top zip")
+
+
+def test_extract_slug_strips_prefix(tmp_path):
+    zp = _build(tmp_path / "ext.zip", {
+        "IL-76MD/Liveries/IL-76MD/MD USSR/description.lua": b"hello\n",
+        "IL-76MD/Liveries/IL-76MD/MD USSR/sub/tex.dds": b"DDS\0",
+    })
+    out = tmp_path / "extracted"
+    n = _extract_slug(
+        zp,
+        ("IL-76MD", "MD USSR", "IL-76MD/Liveries/IL-76MD/MD USSR/"),
+        out,
+    )
+    assert n == 2
+    assert (out / "MD USSR" / "description.lua").read_bytes() == b"hello\n"
+    assert (out / "MD USSR" / "sub" / "tex.dds").read_bytes() == b"DDS\0"
+
+
+def test_extract_slug_skips_traversal(tmp_path):
+    """Defense-in-depth: even if a `..` slipped past the scanner, the
+    extractor must skip it."""
+    zp = _build(tmp_path / "traverse.zip", {
+        "FA-18C_hornet/Skin/../etc/passwd": b"r00t\n",
+        "FA-18C_hornet/Skin/legit.dds": b"DDS\0",
+    })
+    out = tmp_path / "extracted"
+    _extract_slug(
+        zp,
+        ("FA-18C_hornet", "Skin", "FA-18C_hornet/Skin/"),
+        out,
+    )
+    # legit file landed; traversal entry was dropped
+    assert (out / "Skin" / "legit.dds").exists()
+    assert not list(out.parent.glob("**/passwd"))


### PR DESCRIPTION
## Summary

- publish.py real implementation: SSH push slugs to vrs.com:~/livery-source/, trigger incremental rebuild, regen + scp 3 manifests, then commit + push pack.json. Each step graceful no-ops on missing secrets.
- reject.py HMAC-SHA256-signed POST to vrs.com/_internal/livery-flag.php (endpoint itself is Phase 3; client side ready).
- build-aircraft-packs.py: new --aircraft NAME incremental mode + dir-source (--source ~/livery-source) parallel to existing zip-source mode. manifest.json merges rather than replaces.
- extract-livery-source.py: one-shot Liveries.zip -> ~/livery-source/ migration script for vrs.com.
- scan-livery.yml: permissions: contents: write + fetch-depth: 0 so publish.py can git push pack.json.
- test_publish.py: 7 new tests for layout parsing + slug extraction (18/18 scanner tests pass).
- PLAN.md: Phase 2c prereqs checklist + branch protection caveat.

Steps are ordered so vrs.com state stays consistent if the final git push fails: scp manifests BEFORE the commit. Only the local pack.json drifts in that case.

## To flip on full-auto (post-merge)

1. Mint secrets and add to repo Settings -> Secrets and variables -> Actions:
   - VRS_SSH_KEY (dedicated ed25519 private key, multiline value)
   - VRS_SSH_HOST (e.g. customdc@vrs.com)
   - DISCORD_LIVERIES_WEBHOOK
   - DISCORD_STAFF_WEBHOOK
   - DISCORD_ONCALL_ROLE_ID
   - VRS_WEBHOOK_KEY (HMAC key for the Phase 3 quarantine endpoint)
2. Add the public half of VRS_SSH_KEY to vrs.com:~/.ssh/authorized_keys with a command= restriction limiting writes to the publish paths.
3. Allow github-actions[bot] to bypass branch protection on main (Settings -> Branches -> main -> Allow specified actors to bypass required pull requests). Without this the workflow's git push fails on every publish.
4. Deploy scripts to vrs.com:~/bin/:
   - scripts/build-aircraft-packs.py (replaces existing)
   - scripts/extract-livery-source.py
5. One-shot on vrs.com: python3.12 ~/bin/extract-livery-source.py (~25 GB, ~10 min).

## Test plan

- [x] 18/18 scanner tests pass locally
- [x] build-aircraft-packs.py --aircraft IL-76MD smoke test with synthetic livery-source/
- [x] workflow YAML parses with PyYAML
- [ ] Re-trigger scan-livery.yml with IL-76MD.zip after merge to verify publish.py runs through layout parsing + extraction + SKIPPED summary (no secrets yet)
- [ ] Mint VRS_SSH_KEY + VRS_SSH_HOST, re-trigger to verify SSH path
- [ ] Run extract-livery-source.py on vrs.com
- [ ] Mint Discord webhooks + re-trigger to verify embed posts
- [ ] Configure branch protection bypass + re-trigger to verify pack.json commit + push

Generated with [Claude Code](https://claude.com/claude-code)