### PR TITLE
Phase 3: ProjectSend ingest cron + signed-URL + reject webhook

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -12,8 +12,15 @@ Status:
   extract-livery-source.py one-shot migration script. Lands as
   ready-to-fire; gracefully no-ops on each missing secret/prereq.
   See "Phase 2c prereqs to flip on" below.
-- **Phase 3 (ProjectSend cron + signed URL + livery-flag.php endpoint)**
-  is next.
+- **Phase 3 code built 2026-05-27** -- livery-pipeline-cron.py
+  (ProjectSend DB watermark -> workflow_dispatch, 3-layer
+  serialization), livery-db-query.php (DB helper, keeps creds in
+  PHP), livery-blob.php (signed-URL streaming), livery-flag.php
+  (HMAC reject webhook). Pending deploy + PAT -- see "Phase 3
+  deploy checklist" below. **Hard gate: the IL-76MD smoke test of
+  the Phase 2c publish path must pass before the cron is deployed**
+  (a publish bug would otherwise be multiplied across the upload
+  backlog).
 
 Moved from `~/Dev/VRSInfra/planning-liveries-pipeline.md` on
 2026-05-24; that path is now a thin pointer back here.
@@ -143,7 +150,67 @@ publish.py is ordered so vrs.com state stays consistent even if the
 push fails: it deploys the new zip + new manifests BEFORE attempting
 the commit + push. If push fails, the only drift is the repo's
 `liveries-index/<aircraft>/pack.json` vs `origin/main`. The GHA run
-summary surfaces this with a recovery hint.
+summary surfaces this with a recovery hint. `_commit_and_push` also
+fetch+rebase+retries once on non-fast-forward (concurrent run or a
+human push).
+
+**Resolved 2026-05-27:** `main` branch protection had "Require a
+pull request before merging" with no per-actor bypass available
+(classic protection; `github-actions[bot]` can't be added to a
+ruleset bypass either -- only Copilot apps showed). Unchecked
+"Require PR" (kept force-push + deletion guards off). The bot now
+pushes pack.json bumps directly; humans still PR by convention.
+
+---
+
+## Phase 3 deploy checklist
+
+Phase 3 code lives in the repo (built 2026-05-27):
+
+- `scripts/livery-pipeline-cron.py` -> deploy to `~/bin/`
+- `scripts/vrs-web/livery-db-query.php` -> deploy to `~/bin/`
+- `scripts/vrs-web/_internal/livery-blob.php` -> deploy to
+  `~/public_html/_internal/`
+- `scripts/vrs-web/_internal/livery-flag.php` -> deploy to
+  `~/public_html/_internal/`
+
+**Do NOT deploy/run the cron until the IL-76MD smoke test passes.**
+
+User-side prereqs:
+
+1. **GitHub PAT** -- fine-grained, `VictorRomeoSierra/VRSMods` only,
+   **Actions: read+write**. Store on vrs.com at
+   `~/.vrs-pipeline-secrets/gh-token` (mode 0600).
+2. **HMAC key file** -- the same value as the `VRS_WEBHOOK_KEY` repo
+   secret, at `~/.vrs-pipeline-secrets/webhook-key` (mode 0600). This
+   is what livery-flag.php verifies reject.py's signature against.
+3. **Dirs**: `~/quarantine/`, `~/cron-state/` (cron auto-creates, but
+   pre-create for the error_log path the PHP endpoints write to:
+   `~/cron-state/php-internal-error.log`).
+4. **Watermark seeding** -- on first run with a missing
+   `~/cron-state/livery-pipeline.json` the cron seeds to the current
+   DB max and dispatches nothing. To process the 5-upload backlog,
+   write the file by hand to an earlier point, e.g.
+   `{"ts":"2026-05-01 00:00:00","id":0}`, then let the cron run.
+5. **Cron entry** (after smoke test + a manual dry run):
+   ```
+   */2 * * * * /usr/bin/python3.12 /home/customdc/bin/livery-pipeline-cron.py >> /home/customdc/cron-state/livery-pipeline.log 2>&1
+   ```
+
+Serialization: the cron will only ever have one publish in flight
+(flock + queued/in_progress API check + one-dispatch-per-tick), so
+the backlog drains one upload per ~2 min tick -- concurrent publishes
+would race on `manifest.json` and the `main` push.
+
+ProjectSend facts (probed 2026-05-27):
+- Files on disk: `~/public_html/upload/upload/files/<tbl_files.url>`
+  (flat; `disk_folder_year/month` null for current uploads).
+- Uploader email via `tbl_files.user_id -> tbl_users.id`.
+- No category tagging in practice -> cron processes all `local`
+  uploads; the scanner is the gate.
+- The `.rar` upload (id 20) will reject at tier 1 (good -- exercises
+  the reject path); id 18 display-named "Old - Do Not Use -.zip" is
+  skipped by the cron's superseded-file filter.
 
 ---
 

--- a/scripts/livery-pipeline-cron.py
+++ b/scripts/livery-pipeline-cron.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Phase 3 ingest cron: ProjectSend upload -> scan-livery dispatch.
+
+Runs on vrs.com every ~2 minutes. Detects new ProjectSend uploads
+past a watermark, quarantines each raw blob outside the web root,
+mints a short-lived signed URL, and fires the scan-livery workflow
+with the inputs it already expects. The workflow scans + publishes
+(pass) or alerts staff (fail); this cron is purely the front half.
+
+Deploy to: ~/bin/livery-pipeline-cron.py on vrs.com (python3.12).
+Cron entry:
+    */2 * * * * /usr/bin/python3.12 /home/customdc/bin/livery-pipeline-cron.py \
+        >> /home/customdc/cron-state/livery-pipeline.log 2>&1
+
+Serialization (three independent layers, so we never publish two at
+once -- concurrent publishes would race on manifest.json + the main
+push):
+  1. flock on ~/cron-state/.lock -- one tick at a time.
+  2. GitHub API check: defer if any scan-livery run is queued OR
+     in_progress.
+  3. At most ONE dispatch per tick, even when the API shows zero
+     active (covers the queued-creation window).
+
+Watermark (~/cron-state/livery-pipeline.json = {"ts","id"}):
+  - Missing file -> seed to the current DB max and exit WITHOUT
+    dispatching. Backfilling history is an explicit action: write the
+    watermark to an earlier {ts,id} by hand, then let the cron run.
+  - Advanced only after a successful dispatch (or when skipping a
+    superseded/missing row), so a failed dispatch retries next tick.
+
+Secrets (files, never argv/env-echoed):
+  - ~/.vrs-pipeline-secrets/gh-token  -- fine-grained PAT, actions:write
+  DB creds stay inside livery-db-query.php (ProjectSend's config).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+HOME = Path.home()
+REPO = "VictorRomeoSierra/VRSMods"
+WORKFLOW = "scan-livery.yml"
+REF = "main"
+
+DB_HELPER = HOME / "bin" / "livery-db-query.php"
+STORE_BASE = HOME / "public_html" / "upload" / "upload" / "files"
+QUARANTINE = HOME / "quarantine"
+SIGNED_URLS = QUARANTINE / "_signed-urls"
+CRON_STATE = HOME / "cron-state"
+WATERMARK = CRON_STATE / "livery-pipeline.json"
+LOCKFILE = CRON_STATE / ".lock"
+PAT_FILE = HOME / ".vrs-pipeline-secrets" / "gh-token"
+
+BLOB_URL_BASE = "https://victorromeosierra.com/_internal/livery-blob.php"
+TOKEN_TTL = 900  # 15 minutes
+
+API = "https://api.github.com"
+
+# Contributor naming convention for superseded uploads: they rename the
+# display filename to flag it (e.g. id 18 -> "Old - Do Not Use -.zip").
+DO_NOT_USE = re.compile(r"old\s*-?\s*do\s*not\s*use", re.IGNORECASE)
+
+
+def log(msg: str) -> None:
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[{stamp}] {msg}", flush=True)
+
+
+# ----- GitHub API ----------------------------------------------------
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "vrs-livery-cron",
+    }
+
+
+def _api_get(pat: str, path: str) -> tuple[int, dict]:
+    req = urllib.request.Request(API + path, headers=_headers(pat))
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, {}
+    except Exception as e:  # noqa: BLE001
+        log(f"api GET {path} error: {type(e).__name__}: {e}")
+        return -1, {}
+
+
+def active_runs(pat: str) -> int:
+    """Count scan-livery runs that are queued or in_progress.
+
+    Raises on API error -- caller treats that as 'defer this tick'
+    rather than risk dispatching into a race.
+    """
+    total = 0
+    for status in ("queued", "in_progress"):
+        st, data = _api_get(
+            pat,
+            f"/repos/{REPO}/actions/workflows/{WORKFLOW}/runs"
+            f"?status={status}&per_page=1",
+        )
+        if st != 200:
+            raise SystemExit(f"runs query failed (HTTP {st}); deferring tick")
+        total += int(data.get("total_count", 0))
+    return total
+
+
+def dispatch(pat: str, inputs: dict[str, str]) -> bool:
+    body = json.dumps({"ref": REF, "inputs": inputs}).encode("utf-8")
+    req = urllib.request.Request(
+        API + f"/repos/{REPO}/actions/workflows/{WORKFLOW}/dispatches",
+        data=body,
+        method="POST",
+        headers={**_headers(pat), "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status in (201, 204)
+    except urllib.error.HTTPError as e:
+        log(f"dispatch HTTP {e.code}: {e.read().decode('utf-8', 'replace')[:300]}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        log(f"dispatch error: {type(e).__name__}: {e}")
+        return False
+
+
+# ----- DB helper -----------------------------------------------------
+
+
+def php_helper(mode: str, *args: str):
+    proc = subprocess.run(
+        ["php", str(DB_HELPER), mode, *args],
+        capture_output=True, text=True, timeout=60,
+    )
+    out = proc.stdout.strip()
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        raise SystemExit(
+            f"db helper non-JSON (rc={proc.returncode}): "
+            f"{out[:300]} | stderr={proc.stderr[:300]}"
+        )
+    if isinstance(data, dict) and "error" in data:
+        raise SystemExit(f"db helper error: {data['error']}")
+    return data
+
+
+# ----- file / quarantine / token ------------------------------------
+
+
+def resolve_file(row: dict) -> Path | None:
+    url = row["url"]
+    y, m = row.get("disk_folder_year"), row.get("disk_folder_month")
+    candidates: list[Path] = []
+    if y and m:
+        candidates.append(STORE_BASE / f"{y:04d}" / f"{int(m):02d}" / url)
+        candidates.append(STORE_BASE / str(y) / str(m) / url)
+    candidates.append(STORE_BASE / url)
+    for c in candidates:
+        if c.is_file():
+            return c
+    return None
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def quarantine_file(src: Path, sha: str, row: dict) -> None:
+    qdir = QUARANTINE / sha
+    qdir.mkdir(parents=True, exist_ok=True)
+    dest = qdir / "original.zip"
+    if not dest.exists():
+        shutil.copyfile(src, dest)
+    meta = {
+        "upload_id": row["id"],
+        "user_id": row["user_id"],
+        "uploader_email": row.get("uploader_email"),
+        "uploader_user": row.get("uploader_user"),
+        "original_filename": row.get("original_url"),
+        "stored_url": row["url"],
+        "sha256": sha,
+        "size": row.get("size"),
+        "ts": row["ts"],
+        "quarantined_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    (qdir / "meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+
+def mint_token(sha: str) -> str:
+    token = secrets.token_hex(32)
+    payload = {"sha256": sha, "expires": int(time.time()) + TOKEN_TTL}
+    (SIGNED_URLS / f"{token}.json").write_text(
+        json.dumps(payload) + "\n", encoding="utf-8"
+    )
+    return token
+
+
+def clean_expired_tokens() -> None:
+    if not SIGNED_URLS.is_dir():
+        return
+    now = int(time.time())
+    for f in SIGNED_URLS.glob("*.json"):
+        try:
+            if json.loads(f.read_text(encoding="utf-8")).get("expires", 0) < now:
+                f.unlink()
+        except Exception:  # noqa: BLE001
+            f.unlink()  # malformed -> drop
+
+
+# ----- watermark -----------------------------------------------------
+
+
+def load_watermark() -> dict | None:
+    if not WATERMARK.is_file():
+        return None
+    return json.loads(WATERMARK.read_text(encoding="utf-8"))
+
+
+def save_watermark(ts: str, file_id: int) -> None:
+    WATERMARK.write_text(
+        json.dumps({"ts": ts, "id": file_id}, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+# ----- main ----------------------------------------------------------
+
+
+def main() -> int:
+    for d in (CRON_STATE, QUARANTINE, SIGNED_URLS):
+        d.mkdir(parents=True, exist_ok=True)
+
+    # Layer 1: only one tick at a time.
+    lock_fd = open(LOCKFILE, "w")
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        log("another tick holds the lock; exiting")
+        return 0
+
+    clean_expired_tokens()
+
+    if not PAT_FILE.is_file():
+        raise SystemExit(f"missing PAT: {PAT_FILE}")
+    pat = PAT_FILE.read_text(encoding="utf-8").strip()
+
+    # Layer 2: defer if any scan is queued/in_progress.
+    n_active = active_runs(pat)
+    if n_active:
+        log(f"{n_active} scan-livery run(s) active; deferring")
+        return 0
+
+    wm = load_watermark()
+    if wm is None:
+        seed = php_helper("seed")
+        save_watermark(seed["ts"], int(seed["id"]))
+        log(f"seeded watermark -> {seed['ts']}/{seed['id']} (no dispatch on first run)")
+        return 0
+
+    rows = php_helper("query", wm["ts"], str(wm["id"]))
+    if not rows:
+        log("no new uploads")
+        return 0
+
+    for row in rows:
+        name = row.get("filename") or row.get("original_url") or ""
+
+        if DO_NOT_USE.search(name):
+            log(f"skip id {row['id']} (superseded: {name!r}); advancing")
+            save_watermark(row["ts"], row["id"])
+            continue
+
+        path = resolve_file(row)
+        if path is None:
+            log(f"WARN id {row['id']}: file not found (url={row['url']!r}); advancing past")
+            save_watermark(row["ts"], row["id"])
+            continue
+
+        sha = sha256_file(path)
+        quarantine_file(path, sha, row)
+        token = mint_token(sha)
+        inputs = {
+            "sha256": sha,
+            "signed_url": f"{BLOB_URL_BASE}?token={token}",
+            "uploader_email": row.get("uploader_email") or "unknown@victorromeosierra.com",
+            "uploader_id": str(row["user_id"]),
+            "original_filename": row.get("original_url") or name or "upload.zip",
+            "upload_id": str(row["id"]),
+        }
+        if not dispatch(pat, inputs):
+            log(f"dispatch FAILED id {row['id']}; NOT advancing (retry next tick)")
+            return 1
+        save_watermark(row["ts"], row["id"])
+        log(f"dispatched id {row['id']} ({name}) sha={sha[:12]} -> watermark {row['ts']}/{row['id']}")
+        # Layer 3: one dispatch per tick.
+        break
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scanner/publish.py
+++ b/scripts/scanner/publish.py
@@ -255,10 +255,21 @@ def _commit_and_push(repo: Path, file_rel: str, message: str) -> tuple[bool, str
     commit = _git(repo, "commit", "-m", message)
     if commit.returncode != 0:
         return False, f"commit failed: {commit.stderr.strip()[:200]}"
+    # Push with one rebase-retry on non-fast-forward. Serialization on the
+    # cron side stops the automation racing itself, but this also covers a
+    # human pushing to main mid-run or a one-tick serialization miss.
+    push = _git(repo, "push", "origin", "HEAD:main")
+    if push.returncode == 0:
+        return True, "pushed"
+    _git(repo, "fetch", "origin", "main")
+    rb = _git(repo, "rebase", "origin/main")
+    if rb.returncode != 0:
+        _git(repo, "rebase", "--abort")
+        return False, f"rebase failed (conflict?): {rb.stderr.strip()[:200]}"
     push = _git(repo, "push", "origin", "HEAD:main")
     if push.returncode != 0:
-        return False, f"push failed: {push.stderr.strip()[:200]}"
-    return True, "pushed"
+        return False, f"push failed after rebase: {push.stderr.strip()[:200]}"
+    return True, "pushed (after rebase)"
 
 
 def _regen_manifests(repo: Path) -> tuple[bool, str]:

--- a/scripts/vrs-web/_internal/livery-blob.php
+++ b/scripts/vrs-web/_internal/livery-blob.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Phase 3 signed-URL endpoint. Streams a quarantined upload to the
+ * GitHub Actions runner given a valid, unexpired token minted by
+ * livery-pipeline-cron.py. Raw uploads never live in the web root or
+ * the git repo; this is the only way the runner fetches them.
+ *
+ * Deploy to: ~/public_html/_internal/livery-blob.php on vrs.com.
+ *
+ * URL: https://victorromeosierra.com/_internal/livery-blob.php?token=<64hex>
+ */
+
+declare(strict_types=1);
+
+// Never leak filesystem paths via default A2 PHP error pages.
+ini_set('display_errors', '0');
+ini_set('log_errors', '1');
+ini_set('error_log', '/home/customdc/cron-state/php-internal-error.log');
+set_time_limit(0); // large blobs (up to ~300 MB) over a slow link
+
+const QUARANTINE  = '/home/customdc/quarantine';
+const SIGNED_URLS = QUARANTINE . '/_signed-urls';
+
+function deny(int $code, string $msg): void {
+    http_response_code($code);
+    header('Content-Type: text/plain');
+    echo $msg . "\n";
+    exit;
+}
+
+$token = $_GET['token'] ?? '';
+// Token is 64 hex chars (secrets.token_hex(32)). Validate the FORMAT
+// before using it in any path -- ?token=../../x would traverse otherwise.
+if (!is_string($token) || !preg_match('/^[a-f0-9]{64}$/', $token)) {
+    deny(400, 'bad token');
+}
+
+$tokenFile = SIGNED_URLS . '/' . $token . '.json';
+if (!is_file($tokenFile)) {
+    deny(404, 'unknown token');
+}
+
+$meta = json_decode((string)file_get_contents($tokenFile), true);
+if (!is_array($meta) || !isset($meta['sha256'], $meta['expires'])) {
+    deny(404, 'bad token record');
+}
+if ((int)$meta['expires'] < time()) {
+    deny(403, 'token expired');
+}
+
+$sha = (string)$meta['sha256'];
+// Validate the sha256 BEFORE building the quarantine path.
+if (!preg_match('/^[a-f0-9]{64}$/', $sha)) {
+    deny(500, 'bad sha in token');
+}
+
+$blob = QUARANTINE . '/' . $sha . '/original.zip';
+if (!is_file($blob)) {
+    deny(404, 'blob missing');
+}
+
+// Stream in chunks -- readfile() does not buffer the whole file in
+// memory, but kill any output buffering first to be sure PHP-FPM
+// doesn't accumulate a 280 MB blob and OOM on shared hosting.
+while (ob_get_level() > 0) {
+    ob_end_clean();
+}
+header('Content-Type: application/zip');
+header('Content-Length: ' . filesize($blob));
+header('Content-Disposition: attachment; filename="livery.zip"');
+header('X-Content-Type-Options: nosniff');
+readfile($blob);
+exit;

--- a/scripts/vrs-web/_internal/livery-flag.php
+++ b/scripts/vrs-web/_internal/livery-flag.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Phase 3 reject/quarantine webhook. scripts/scanner/reject.py POSTs
+ * an HMAC-SHA256-signed verdict here when a scan fails; we write a
+ * REJECTED.json next to the quarantined sample so staff/tooling can
+ * list rejections. The raw upload stays in ~/quarantine/ as forensic
+ * evidence.
+ *
+ * Deploy to: ~/public_html/_internal/livery-flag.php on vrs.com.
+ *
+ * Auth: X-VRS-Signature = hex(HMAC-SHA256(key, raw_body)), where key is
+ * the shared secret in ~/.vrs-pipeline-secrets/webhook-key (must equal
+ * the VRS_WEBHOOK_KEY repo secret reject.py signs with). A replay window
+ * bounds stale/replayed posts.
+ *
+ * Payload (compact JSON, signed as exact bytes):
+ *   {"sha256":"<hex>","verdict":"REJECT","reasons":[...],"ts":<unix>}
+ */
+
+declare(strict_types=1);
+
+ini_set('display_errors', '0');
+ini_set('log_errors', '1');
+ini_set('error_log', '/home/customdc/cron-state/php-internal-error.log');
+
+const QUARANTINE = '/home/customdc/quarantine';
+const KEY_FILE   = '/home/customdc/.vrs-pipeline-secrets/webhook-key';
+const MAX_SKEW   = 300; // seconds; reject.py stamps ts at send time
+
+function deny(int $code, string $msg): void {
+    http_response_code($code);
+    header('Content-Type: text/plain');
+    echo $msg . "\n";
+    exit;
+}
+
+if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+    deny(405, 'POST only');
+}
+if (!is_file(KEY_FILE)) {
+    deny(500, 'server not configured');
+}
+$key = trim((string)file_get_contents(KEY_FILE));
+if ($key === '') {
+    deny(500, 'server not configured');
+}
+
+// HMAC over the EXACT received bytes -- not a re-serialized payload.
+$body = (string)file_get_contents('php://input');
+$sent = $_SERVER['HTTP_X_VRS_SIGNATURE'] ?? '';
+$expected = hash_hmac('sha256', $body, $key);
+if (!is_string($sent) || !hash_equals($expected, $sent)) {
+    deny(401, 'bad signature');
+}
+
+$payload = json_decode($body, true);
+if (!is_array($payload) || !isset($payload['sha256'], $payload['ts'], $payload['verdict'])) {
+    deny(400, 'bad payload');
+}
+
+// Replay window.
+if (abs(time() - (int)$payload['ts']) > MAX_SKEW) {
+    deny(401, 'stale timestamp');
+}
+
+$sha = (string)$payload['sha256'];
+if (!preg_match('/^[a-f0-9]{64}$/', $sha)) {
+    deny(400, 'bad sha');
+}
+
+$qdir = QUARANTINE . '/' . $sha;
+if (!is_dir($qdir)) {
+    // Normally the cron created this when it quarantined the upload.
+    // Create it anyway so a rejection is never silently dropped.
+    @mkdir($qdir, 0700, true);
+}
+
+$record = [
+    'sha256'      => $sha,
+    'verdict'     => $payload['verdict'],
+    'reasons'     => $payload['reasons'] ?? [],
+    'sent_ts'     => (int)$payload['ts'],
+    'received_at' => gmdate('Y-m-d\TH:i:s\Z'),
+];
+$ok = file_put_contents(
+    $qdir . '/REJECTED.json',
+    json_encode($record, JSON_PRETTY_PRINT) . "\n",
+    LOCK_EX
+);
+if ($ok === false) {
+    deny(500, 'write failed');
+}
+
+http_response_code(204);

--- a/scripts/vrs-web/livery-db-query.php
+++ b/scripts/vrs-web/livery-db-query.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Phase 3 DB helper for livery-pipeline-cron.py.
+ *
+ * Keeps ProjectSend's MySQL credentials inside PHP (they live as
+ * constants in ProjectSend's sys.config.php) so the Python cron never
+ * needs a MySQL driver or the raw password. Emits JSON on stdout.
+ *
+ * Deploy to: ~/bin/livery-db-query.php on vrs.com (NOT web-accessible).
+ *
+ * Modes:
+ *   php livery-db-query.php seed
+ *     -> {"ts":"YYYY-MM-DD HH:MM:SS","id":N}  current max watermark
+ *        (used to seed ~/cron-state on first run, no dispatch)
+ *
+ *   php livery-db-query.php query "<ts>" <id>
+ *     -> [ {row}, ... ]  uploads strictly after (ts,id), local storage
+ *        only, oldest first, joined to tbl_users for uploader email.
+ *
+ * Exit non-zero + JSON {"error":...} on failure so the cron can detect
+ * and skip the tick rather than advancing the watermark.
+ */
+
+declare(strict_types=1);
+
+$CONFIG = '/home/customdc/public_html/upload/includes/sys.config.php';
+
+function fail(string $msg): void {
+    fwrite(STDERR, $msg . "\n");
+    echo json_encode(["error" => $msg]) . "\n";
+    exit(1);
+}
+
+if (!is_file($CONFIG)) {
+    fail("config not found: $CONFIG");
+}
+require $CONFIG;
+
+$prefix = defined('TABLES_PREFIX') ? TABLES_PREFIX : 'tbl_';
+$db = @new mysqli(DB_HOST, DB_USER, DB_PASSWORD, DB_NAME);
+if ($db->connect_errno) {
+    fail("db connect failed: " . $db->connect_error);
+}
+$db->set_charset('utf8mb4');
+
+$mode = $argv[1] ?? '';
+
+if ($mode === 'seed') {
+    $res = $db->query(
+        "SELECT DATE_FORMAT(MAX(timestamp), '%Y-%m-%d %H:%i:%s') AS ts,
+                COALESCE(MAX(id), 0) AS id
+         FROM {$prefix}files"
+    );
+    if (!$res) { fail("seed query failed: " . $db->error); }
+    $row = $res->fetch_assoc();
+    echo json_encode([
+        "ts" => $row['ts'] ?? '1970-01-01 00:00:00',
+        "id" => (int)($row['id'] ?? 0),
+    ]) . "\n";
+    exit(0);
+}
+
+if ($mode === 'query') {
+    $ts = $argv[2] ?? '1970-01-01 00:00:00';
+    $id = (int)($argv[3] ?? 0);
+
+    $sql =
+        "SELECT f.id, f.user_id, f.url, f.original_url, f.filename,
+                f.size, f.storage_type,
+                f.disk_folder_year, f.disk_folder_month,
+                DATE_FORMAT(f.timestamp, '%Y-%m-%d %H:%i:%s') AS ts,
+                u.email AS uploader_email, u.user AS uploader_user
+         FROM {$prefix}files f
+         LEFT JOIN {$prefix}users u ON u.id = f.user_id
+         WHERE f.storage_type = 'local'
+           AND ( f.timestamp > ? OR (f.timestamp = ? AND f.id > ?) )
+         ORDER BY f.timestamp ASC, f.id ASC
+         LIMIT 50";
+    $stmt = $db->prepare($sql);
+    if (!$stmt) { fail("prepare failed: " . $db->error); }
+    $stmt->bind_param('ssi', $ts, $ts, $id);
+    if (!$stmt->execute()) { fail("execute failed: " . $stmt->error); }
+    $res = $stmt->get_result();
+
+    $rows = [];
+    while ($r = $res->fetch_assoc()) {
+        $rows[] = [
+            "id"                => (int)$r['id'],
+            "user_id"           => (int)$r['user_id'],
+            "url"               => $r['url'],
+            "original_url"      => $r['original_url'],
+            "filename"          => $r['filename'],
+            "size"              => (int)$r['size'],
+            "disk_folder_year"  => $r['disk_folder_year'] !== null ? (int)$r['disk_folder_year'] : null,
+            "disk_folder_month" => $r['disk_folder_month'] !== null ? (int)$r['disk_folder_month'] : null,
+            "ts"                => $r['ts'],
+            "uploader_email"    => $r['uploader_email'],
+            "uploader_user"     => $r['uploader_user'],
+        ];
+    }
+    echo json_encode($rows) . "\n";
+    exit(0);
+}
+
+fail("unknown mode: '$mode' (expected 'seed' or 'query')");


### PR DESCRIPTION
## Summary

Front half of the pipeline: detect a ProjectSend upload and hand it to the existing scan-livery workflow. Builds on the merged Phase 2c publish path.

- `scripts/livery-pipeline-cron.py` - DB-watermark detector that dispatches scan-livery. Three serialization layers (flock, queued/in_progress API check, one dispatch per tick) so publishes never run concurrently and race on manifest.json or the main push. Watermark seeds to DB-max on first run; backfilling is an explicit hand-edit. Skips superseded "Old - Do Not Use" uploads.
- `scripts/vrs-web/livery-db-query.php` - DB helper that keeps ProjectSend's MySQL creds inside PHP (no Python mysql driver needed on the host). Seed + query modes, emits JSON.
- `scripts/vrs-web/_internal/livery-blob.php` - signed-URL streaming endpoint. random_bytes(32) tokens, sha256 regex-validated before path construction, readfile streaming (no full-file buffering), display_errors off, error_log outside the web root.
- `scripts/vrs-web/_internal/livery-flag.php` - reject webhook. HMAC-SHA256 verified with hash_equals (constant-time) and a 300s replay window; writes REJECTED.json next to the quarantined sample.
- `scripts/scanner/publish.py` - push now fetch+rebase+retries once on non-fast-forward.
- `PLAN.md` - Phase 3 deploy checklist + ProjectSend schema facts.

## Deploy gate

Not to be deployed/run until the IL-76MD smoke test of the Phase 2c publish path passes. A publish bug would otherwise be multiplied across the 5-upload backlog. Deploy steps + the user-side PAT/HMAC-key/watermark prereqs are in PLAN.md.

## Test plan

- [x] Python compiles, 18/18 scanner tests pass
- [x] All three PHP files lint clean (php -l) on the host
- [ ] IL-76MD smoke test (Phase 2c publish path) green - GATE
- [ ] Deploy scripts to vrs.com, mint PAT + webhook-key file
- [ ] Dry-run cron with watermark seeded before 2026-05-14 to drain the 5-upload backlog
- [ ] Confirm 4 zips publish + the .rar rejects with a staff Discord alert

Generated with [Claude Code](https://claude.com/claude-code)